### PR TITLE
RavenDB-24162 : Retire attachments - Client Api - add authorization c…

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Retired/AbstractRetiredAttachmentHandlerProcessorForAddRetireConfig.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Retired/AbstractRetiredAttachmentHandlerProcessorForAddRetireConfig.cs
@@ -5,6 +5,7 @@ using Raven.Server.Documents.Handlers.Processors.Databases;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Handlers.Processors.Attachments.Retired;
 
@@ -30,6 +31,8 @@ internal abstract class AbstractRetiredAttachmentHandlerProcessorForAddRetireCon
 
     protected override Task<(long Index, object Result)> OnUpdateConfiguration(TransactionOperationContext context, RetiredAttachmentsConfiguration configuration, string raftRequestId)
     {
+        if (LoggingSource.Instance.IsInfoEnabled)
+            RequestHandler.LogAuditFor(RequestHandler.DatabaseName, $"User '{RequestHandler.HttpContext.User?.Identity?.Name}' updated retire-attachments configuration", "retired_attachments-config");
         return RequestHandler.ServerStore.ModifyDatabaseAttachmentsRetire(context, RequestHandler.DatabaseName, configuration, raftRequestId);
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Retired/AbstractRetiredAttachmentHandlerProcessorForAddRetireConfig.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Retired/AbstractRetiredAttachmentHandlerProcessorForAddRetireConfig.cs
@@ -31,7 +31,7 @@ internal abstract class AbstractRetiredAttachmentHandlerProcessorForAddRetireCon
 
     protected override Task<(long Index, object Result)> OnUpdateConfiguration(TransactionOperationContext context, RetiredAttachmentsConfiguration configuration, string raftRequestId)
     {
-        if (LoggingSource.Instance.IsInfoEnabled)
+        if (LoggingSource.AuditLog.IsInfoEnabled)
             RequestHandler.LogAuditFor(RequestHandler.DatabaseName, $"User '{RequestHandler.HttpContext.User?.Identity?.Name}' updated retire-attachments configuration", "retired_attachments-config");
         return RequestHandler.ServerStore.ModifyDatabaseAttachmentsRetire(context, RequestHandler.DatabaseName, configuration, raftRequestId);
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Retired/RetiredAttachmentHandlerProcessorForGetRetireConfig.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Retired/RetiredAttachmentHandlerProcessorForGetRetireConfig.cs
@@ -3,6 +3,7 @@ using JetBrains.Annotations;
 using Raven.Client.Documents.Attachments;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Handlers.Processors.Attachments.Retired;
 
@@ -22,6 +23,10 @@ internal sealed class RetiredAttachmentHandlerProcessorForGetRetireConfig : Abst
             {
                 configuration = rawRecord?.RetiredAttachmentsConfiguration;
             }
+
+            if (LoggingSource.Instance.IsInfoEnabled)
+                RequestHandler.LogAuditFor(RequestHandler.DatabaseName, $"User '{RequestHandler.HttpContext.User?.Identity}' fetched retire-attachment configurations ",
+                    "retired_attachments-config");
             return ValueTask.FromResult(configuration);
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Retired/RetiredAttachmentHandlerProcessorForGetRetireConfig.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Retired/RetiredAttachmentHandlerProcessorForGetRetireConfig.cs
@@ -24,7 +24,7 @@ internal sealed class RetiredAttachmentHandlerProcessorForGetRetireConfig : Abst
                 configuration = rawRecord?.RetiredAttachmentsConfiguration;
             }
 
-            if (LoggingSource.Instance.IsInfoEnabled)
+            if (LoggingSource.AuditLog.IsInfoEnabled)
                 RequestHandler.LogAuditFor(RequestHandler.DatabaseName, $"User '{RequestHandler.HttpContext.User?.Identity}' fetched retire-attachment configurations ",
                     "retired_attachments-config");
             return ValueTask.FromResult(configuration);

--- a/test/SlowTests/Issues/RavenDB_24162.cs
+++ b/test/SlowTests/Issues/RavenDB_24162.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using FastTests;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Operations.Attachments.Retired;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Exceptions.Security;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Sparrow.Logging;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24162 : RavenTestBase
+    {
+        public RavenDB_24162(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private RetiredAttachmentsConfiguration SampleConfig() => new RetiredAttachmentsConfiguration
+        {
+            Disabled = true,
+            RetireFrequencyInSec = 123456,
+            S3Settings = new S3Settings
+            {
+                BucketName = "test-bucket-does-not-exist", AwsRegionName = "us-west-2", AwsAccessKey = "AKIAFAKEKEY", AwsSecretKey = "FAKESECRET"
+            }
+        };
+
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanGetRetireConfigWithValidUserPermission(Options options)
+        {
+            LoggingSource.AuditLog.SetupLogMode(LogMode.Information, "c:/temp", TimeSpan.MaxValue, null, false);
+
+            var certs = Certificates.SetupServerAuthentication();
+            var db = GetDatabaseName();
+
+            var adminCert = Certificates.RegisterClientCertificate(
+                certs.ServerCertificate.Value,
+                certs.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess> { [db] = DatabaseAccess.Admin },
+                SecurityClearance.ClusterAdmin);
+
+            var userCert = Certificates.RegisterClientCertificate(
+                certs.ServerCertificate.Value,
+                certs.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess> { [db] = DatabaseAccess.Read },
+                SecurityClearance.ValidUser);
+
+            options.AdminCertificate = adminCert;
+            options.ClientCertificate = userCert;
+            options.ModifyDatabaseName = _ => db;
+
+            using (var store = GetDocumentStore(options))
+            {
+                var cfg = store.Maintenance.Send(new GetRetireAttachmentsConfigurationOperation());
+                Assert.Null(cfg);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanAddRetireConfigWithDatabaseAdminPermission(Options options)
+        {
+            LoggingSource.AuditLog.SetupLogMode(LogMode.Information, "c:/temp", TimeSpan.MaxValue, null, false);
+
+            var certs = Certificates.SetupServerAuthentication();
+            var db = GetDatabaseName();
+
+            var adminCert = Certificates.RegisterClientCertificate(
+                certs.ServerCertificate.Value,
+                certs.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess> { [db] = DatabaseAccess.Admin },
+                SecurityClearance.ClusterAdmin);
+
+            var userCert = Certificates.RegisterClientCertificate(
+                certs.ServerCertificate.Value,
+                certs.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess> { [db] = DatabaseAccess.Admin });
+
+            options.AdminCertificate = adminCert;
+            options.ClientCertificate = userCert;
+            options.ModifyDatabaseName = _ => db;
+
+            using (var store = GetDocumentStore(options))
+            {
+                var cfg = SampleConfig();
+
+                store.Maintenance.Send(new ConfigureRetiredAttachmentsOperation(cfg));
+
+                var returned = store.Maintenance.Send(new GetRetireAttachmentsConfigurationOperation());
+                Assert.True(returned.Disabled);
+                var x = returned.RetireFrequencyInSec;
+                Assert.Equal(123456, returned.RetireFrequencyInSec);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void CannotAddRetireConfigWithoutDatabaseAdminPermission(Options options)
+        {
+            LoggingSource.AuditLog.SetupLogMode(LogMode.Information, "c:/temp", TimeSpan.MaxValue, null, false);
+
+            var certs = Certificates.SetupServerAuthentication();
+            var db = GetDatabaseName();
+
+            var adminCert = Certificates.RegisterClientCertificate(
+                certs.ServerCertificate.Value,
+                certs.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess> { [db] = DatabaseAccess.Admin },
+                SecurityClearance.ClusterAdmin);
+
+            var userCert = Certificates.RegisterClientCertificate(
+                certs.ServerCertificate.Value,
+                certs.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess> { [db] = DatabaseAccess.ReadWrite },
+                SecurityClearance.ValidUser);
+
+            options.AdminCertificate = adminCert;
+            options.ClientCertificate = userCert;
+            options.ModifyDatabaseName = _ => db;
+
+            using (var store = GetDocumentStore(options))
+            {
+                var cfg = SampleConfig();
+
+                Assert.Throws<AuthorizationException>(() =>
+                    store.Maintenance.Send(new ConfigureRetiredAttachmentsOperation(cfg)));
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_24162.cs
+++ b/test/SlowTests/Issues/RavenDB_24162.cs
@@ -33,8 +33,6 @@ namespace SlowTests.Issues
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public void CanGetRetireConfigWithValidUserPermission(Options options)
         {
-            LoggingSource.AuditLog.SetupLogMode(LogMode.Information, "c:/temp", TimeSpan.MaxValue, null, false);
-
             var certs = Certificates.SetupServerAuthentication();
             var db = GetDatabaseName();
 
@@ -57,7 +55,6 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore(options))
             {
                 var cfg = store.Maintenance.Send(new GetRetireAttachmentsConfigurationOperation());
-                Assert.Null(cfg);
             }
         }
 
@@ -65,8 +62,6 @@ namespace SlowTests.Issues
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public void CanAddRetireConfigWithDatabaseAdminPermission(Options options)
         {
-            LoggingSource.AuditLog.SetupLogMode(LogMode.Information, "c:/temp", TimeSpan.MaxValue, null, false);
-
             var certs = Certificates.SetupServerAuthentication();
             var db = GetDatabaseName();
 
@@ -102,8 +97,6 @@ namespace SlowTests.Issues
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public void CannotAddRetireConfigWithoutDatabaseAdminPermission(Options options)
         {
-            LoggingSource.AuditLog.SetupLogMode(LogMode.Information, "c:/temp", TimeSpan.MaxValue, null, false);
-
             var certs = Certificates.SetupServerAuthentication();
             var db = GetDatabaseName();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24162/Retire-attachments-Client-Api-add-authorization-checks-Phase-1

### Additional description

This PR restores the missing permission checks on the “retire attachments” configuration endpoints:
POST /databases/*/admin/attachments/retire/config now requires DatabaseAdmin.
Certificate-based tests have been added.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
