### PR TITLE
RavenDB-24489: Add test that verifies the ability to index the attachment by attachment flag or @retiredAt properties

### DIFF
--- a/test/SlowTests/Issues/RavenDB-24489.cs
+++ b/test/SlowTests/Issues/RavenDB-24489.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Microsoft.IdentityModel.Tokens;
+using RabbitMQ.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Json;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24489 : RavenTestBase
+    {
+        public RavenDB_24489(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Attachments)]
+        public async Task Index_ShouldInclude_RetiredFlag_And_RetiredAt_ForRetiredAttachments()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "John" }, "users/1");
+                await session.StoreAsync(new User { Name = "Johny" }, "users/2");
+                await session.SaveChangesAsync();
+            }
+
+            var retireAt1 = DateTime.UtcNow.AddDays(7);
+            var retireAt2 = DateTime.UtcNow.AddDays(365);
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("hello")))
+            {
+                var parameters1 = new StoreAttachmentParameters("greeting1.txt", ms) { RetireAt = retireAt1 };
+                var putOp1 = new PutAttachmentOperation("users/1", parameters1);
+                store.Operations.Send(putOp1);
+                ms.Position = 0;
+                var parameters2 = new StoreAttachmentParameters("greeting2.txt", ms) { RetireAt = retireAt2 };
+                var putOp2 = new PutAttachmentOperation("users/2", parameters2);
+                store.Operations.Send(putOp2);
+                ms.Position = 0;
+                var parameters3 = new StoreAttachmentParameters("greeting3.txt", ms) { RetireAt = retireAt2 };
+                var putOp3= new PutAttachmentOperation("users/2", parameters3);
+                store.Operations.Send(putOp3);
+            }
+
+            var index = new RetiredAttachmentIndex();
+            await index.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
+
+            using (var session = store.OpenSession())
+            {
+                var result = session.
+                    Query<RetiredAttachmentIndex.Result, RetiredAttachmentIndex>().
+                    Where(x => x.RetiredAt != null && x.RetiredAt > DateTime.UtcNow.AddDays(8)).
+                    ToList();
+
+                Assert.NotNull(result);
+                Assert.Single(result);
+                Assert.True(result[0].Name == "Johny");
+                Assert.True(result[0].Id == "users/2");
+
+                var result2 = session.
+                    Query<RetiredAttachmentIndex.Result, RetiredAttachmentIndex>().
+                    Where(x => x.RetiredAt != null && x.RetiredAt > DateTime.UtcNow.AddDays(8)).
+                    ProjectInto<RetiredAttachmentIndex.Result>().
+                    ToList();
+
+                Assert.NotNull(result);
+                Assert.Equal(2, result2.Count);
+                Assert.All(result2, x =>
+                {
+                    Assert.True(x.RetiredAt.HasValue, "RetiredAt should not be null");
+                    Assert.True(x.RetiredAt.Value > DateTime.UtcNow.AddDays(8),
+                        $"RetiredAt {x.RetiredAt} should be > now+8d");
+                    Assert.False(x.Retired, "should be retired only 8 days from now");
+                    Assert.StartsWith("greeting", x.Name);
+                });
+            }
+        }
+
+        private class RetiredAttachmentIndex : AbstractIndexCreationTask<User, RetiredAttachmentIndex.Result>
+        {
+            public class Result
+            {
+                public string Id { get; set; }
+                public string Name { get; set; }
+                public bool Retired { get; set; }
+                public DateTime? RetiredAt { get; set; }
+            }
+
+            public RetiredAttachmentIndex()
+            {
+        
+                Map = users => from u in users
+                    let attachments = AttachmentsFor(u) 
+                    from att in attachments
+                    select new Result
+                    {
+                        Name = att.Name,
+                        RetiredAt = att.RetireAt
+                    };
+                StoreAllFields(FieldStorage.Yes);
+            }
+        }
+        
+        public class User
+        { 
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-24489.cs
+++ b/test/SlowTests/Issues/RavenDB-24489.cs
@@ -4,88 +4,189 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using FastTests;
-using Microsoft.IdentityModel.Tokens;
-using RabbitMQ.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Attachments;
-using Raven.Client.Documents.Operations.Indexes;
-using Raven.Client.Json;
-using Sparrow.Json;
+using Raven.Client.Documents.Operations.Attachments.Retired;
+using SlowTests.Server.Documents.Attachments;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
-    public class RavenDB_24489 : RavenTestBase
+    public class RavenDB_24489 : RetiredAttachmentsS3Base
     {
         public RavenDB_24489(ITestOutputHelper output) : base(output)
         {
         }
-
-        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Attachments)]
+        
+        [AmazonS3RetryFact]
         public async Task Index_ShouldInclude_RetiredFlag_And_RetiredAt_ForRetiredAttachments()
         {
-            using var store = GetDocumentStore();
+            string remoteFolderName = "RavenDB_24489";
+            var s3Settings = Etl.GetS3Settings(remoteFolderName);
 
-            using (var session = store.OpenAsyncSession())
+            try
             {
-                await session.StoreAsync(new User { Name = "John" }, "users/1");
-                await session.StoreAsync(new User { Name = "Johny" }, "users/2");
-                await session.SaveChangesAsync();
-            }
+                using var store = GetDocumentStore();
 
-            var retireAt1 = DateTime.UtcNow.AddDays(7);
-            var retireAt2 = DateTime.UtcNow.AddDays(365);
-            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("hello")))
-            {
-                var parameters1 = new StoreAttachmentParameters("greeting1.txt", ms) { RetireAt = retireAt1 };
-                var putOp1 = new PutAttachmentOperation("users/1", parameters1);
-                store.Operations.Send(putOp1);
-                ms.Position = 0;
-                var parameters2 = new StoreAttachmentParameters("greeting2.txt", ms) { RetireAt = retireAt2 };
-                var putOp2 = new PutAttachmentOperation("users/2", parameters2);
-                store.Operations.Send(putOp2);
-                ms.Position = 0;
-                var parameters3 = new StoreAttachmentParameters("greeting3.txt", ms) { RetireAt = retireAt2 };
-                var putOp3= new PutAttachmentOperation("users/2", parameters3);
-                store.Operations.Send(putOp3);
-            }
+                var conf = new RetiredAttachmentsConfiguration { Disabled = false, RetireFrequencyInSec = 1, S3Settings = s3Settings };
+                await store.Maintenance.ForDatabase(store.Database).SendAsync(new ConfigureRetiredAttachmentsOperation(conf));
 
-            var index = new RetiredAttachmentIndex();
-            await index.ExecuteAsync(store);
-            await Indexes.WaitForIndexingAsync(store);
-
-            using (var session = store.OpenSession())
-            {
-                var result = session.
-                    Query<RetiredAttachmentIndex.Result, RetiredAttachmentIndex>().
-                    Where(x => x.RetiredAt != null && x.RetiredAt > DateTime.UtcNow.AddDays(8)).
-                    ToList();
-
-                Assert.NotNull(result);
-                Assert.Single(result);
-                Assert.True(result[0].Name == "Johny");
-                Assert.True(result[0].Id == "users/2");
-
-                var result2 = session.
-                    Query<RetiredAttachmentIndex.Result, RetiredAttachmentIndex>().
-                    Where(x => x.RetiredAt != null && x.RetiredAt > DateTime.UtcNow.AddDays(8)).
-                    ProjectInto<RetiredAttachmentIndex.Result>().
-                    ToList();
-
-                Assert.NotNull(result);
-                Assert.Equal(2, result2.Count);
-                Assert.All(result2, x =>
+                using (var session = store.OpenAsyncSession())
                 {
-                    Assert.True(x.RetiredAt.HasValue, "RetiredAt should not be null");
-                    Assert.True(x.RetiredAt.Value > DateTime.UtcNow.AddDays(8),
-                        $"RetiredAt {x.RetiredAt} should be > now+8d");
-                    Assert.False(x.Retired, "should be retired only 8 days from now");
-                    Assert.StartsWith("greeting", x.Name);
-                });
+                    await session.StoreAsync(new User { Name = "John" }, "users/1");
+                    await session.StoreAsync(new User { Name = "Johny" }, "users/2");
+                    await session.StoreAsync(new User { Name = "JohnySilverhand" }, "users/3");
+                    await session.SaveChangesAsync();
+                }
+
+                DateTime baseline = DateTime.UtcNow;
+                var retireAt1 = baseline.AddDays(7);
+                var retireAt2 = baseline.AddDays(365);
+                var retireAt3 = baseline.AddMinutes(1);
+
+                using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("hello")))
+                {
+                    var parameters1 = new StoreAttachmentParameters("greeting1.txt", ms) { RetireAt = retireAt1 };
+                    var putOp1 = new PutAttachmentOperation("users/1", parameters1);
+                    store.Operations.Send(putOp1);
+                    ms.Position = 0;
+                    var parameters2 = new StoreAttachmentParameters("greeting2.txt", ms) { RetireAt = retireAt2 };
+                    var putOp2 = new PutAttachmentOperation("users/2", parameters2);
+                    store.Operations.Send(putOp2);
+                    ms.Position = 0;
+                    var parameters3 = new StoreAttachmentParameters("greeting3.txt", ms) { RetireAt = retireAt2 };
+                    var putOp3 = new PutAttachmentOperation("users/2", parameters3);
+                    store.Operations.Send(putOp3);
+                    ms.Position = 0;
+                    var parameters4 = new StoreAttachmentParameters("greeting4.txt", ms) { RetireAt = retireAt3 };
+                    var putOp4 = new PutAttachmentOperation("users/3", parameters4);
+                    store.Operations.Send(putOp4);
+                }
+
+                int count = 0;
+                var retired = await WaitForValueAsync(async () =>
+                {
+                    var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                    database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(3);
+                    count += await database.RetireAttachmentsSender.RetireAttachments(int.MaxValue, int.MaxValue);
+                    return count;
+                }, 1, interval: 1000);
+
+                var index = new RetiredAttachmentIndex();
+                await index.ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var result = session.Query<RetiredAttachmentIndex.Result, RetiredAttachmentIndex>()
+                        .Where(x => x.RetiredAt != null && x.RetiredAt > baseline.AddDays(8)).ToList();
+
+                    Assert.NotNull(result);
+                    Assert.Single(result);
+                    Assert.True(result[0].Name == "Johny");
+                    Assert.True(result[0].Id == "users/2");
+
+                    var resultWithProjection = session.Query<RetiredAttachmentIndex.Result, RetiredAttachmentIndex>()
+                        .Where(x => x.RetiredAt != null && x.RetiredAt > baseline).ProjectInto<RetiredAttachmentIndex.Result>().ToList();
+
+                    Assert.NotNull(result);
+                    Assert.Equal(4, resultWithProjection.Count);
+                    Assert.All(resultWithProjection, x =>
+                    {
+                        Assert.True(x.RetiredAt.HasValue, "RetiredAt should not be null here");
+                        Assert.True(x.RetiredAt.Value > baseline,
+                            $"RetiredAt {x.RetiredAt} should be > baseline");
+                        Assert.StartsWith("greeting", x.Name);
+                    });
+
+                    var resultByFlag = session.Query<RetiredAttachmentIndex.Result, RetiredAttachmentIndex>().Where(x => x.Retired == AttachmentFlags.Retired)
+                        .ProjectInto<RetiredAttachmentIndex.Result>().ToList();
+
+                    Assert.NotNull(resultByFlag);
+                    Assert.Equal(1, resultByFlag.Count);
+                }
+            }
+            finally
+            {
+                await DeleteObjects(s3Settings);
+            }
+        }
+
+        [AmazonS3RetryFact]
+        public async Task Index_ShouldInclude_RetiredFlag_And_RetiredAt_ForRetiredAttachments_LoadAttachments()
+        {
+            string remoteFolderName = "RavenDB_24489";
+            var s3Settings = Etl.GetS3Settings(remoteFolderName);
+
+            try
+            {
+                using var store = GetDocumentStore();
+
+                var conf = new RetiredAttachmentsConfiguration { Disabled = false, RetireFrequencyInSec = 1, S3Settings = s3Settings };
+                await store.Maintenance.ForDatabase(store.Database).SendAsync(new ConfigureRetiredAttachmentsOperation(conf));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "John", AttName = "myAttachment.png" }, "users/1");
+                    await session.StoreAsync(new User { Name = "Johny", AttName = "myPhoto.png" }, "users/2" );
+                    await session.SaveChangesAsync();
+                }
+
+                DateTime baseline = DateTime.UtcNow;
+                var retireAt1 = baseline.AddDays(7);
+                var retireAt2 = baseline.AddMinutes(1);
+                var retireAt3 = baseline.AddDays(365);
+                using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("hello")))
+                {
+                    var parameters1 = new StoreAttachmentParameters("myAttachment.png", ms) { RetireAt = retireAt1 };
+                    var putOp1 = new PutAttachmentOperation("users/1", parameters1);
+                    store.Operations.Send(putOp1);
+                    ms.Position = 0;
+                    var parameters2 = new StoreAttachmentParameters("myPhoto.png", ms) { RetireAt = retireAt2 };
+                    var putOp2 = new PutAttachmentOperation("users/2", parameters2);
+                    store.Operations.Send(putOp2);
+                    ms.Position = 0;
+                    var parameters3 = new StoreAttachmentParameters("greeting3.txt", ms) { RetireAt = retireAt3 };
+                    var putOp3 = new PutAttachmentOperation("users/2", parameters3);
+                    store.Operations.Send(putOp3);
+                }
+                int count = 0;
+                var retired = await WaitForValueAsync(async () =>
+                {
+                    var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                    database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(3);
+                    count += await database.RetireAttachmentsSender.RetireAttachments(int.MaxValue, int.MaxValue);
+                    return count;
+                }, 1, interval: 1000);
+
+                var index = new RetiredAttachmentIndex();
+                await index.ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var result = session.Query<RetiredAttachmentIndex_LoadAttachments.Result, RetiredAttachmentIndex>()
+                        .Where(x => x.RetiredAt != null && x.RetiredAt > baseline.AddMinutes(5)).ToList();
+
+                    Assert.NotNull(result);
+                    Assert.True(result.Count == 2);
+
+                    var resultByFlag = session.Query<RetiredAttachmentIndex.Result, RetiredAttachmentIndex>().Where(x => x.Retired == AttachmentFlags.Retired)
+                        .ProjectInto<RetiredAttachmentIndex.Result>().ToList();
+
+                    Assert.NotNull(resultByFlag);
+                    Assert.Equal(1, resultByFlag.Count);
+                }
+            }
+            finally
+            {
+                await DeleteObjects(s3Settings);
             }
         }
 
@@ -95,30 +196,54 @@ namespace SlowTests.Issues
             {
                 public string Id { get; set; }
                 public string Name { get; set; }
-                public bool Retired { get; set; }
+                public AttachmentFlags Retired { get; set; }
                 public DateTime? RetiredAt { get; set; }
             }
 
             public RetiredAttachmentIndex()
             {
-        
                 Map = users => from u in users
-                    let attachments = AttachmentsFor(u) 
-                    from att in attachments
-                    select new Result
-                    {
+                    from att in AttachmentsFor(u)
+                    select new Result { 
                         Name = att.Name,
-                        RetiredAt = att.RetireAt
+                        Retired = att.Flags,
+                        RetiredAt = att.RetireAt,
                     };
                 StoreAllFields(FieldStorage.Yes);
             }
         }
+
+        private class RetiredAttachmentIndex_LoadAttachments : AbstractIndexCreationTask<User, RetiredAttachmentIndex.Result>
+        {
+            public class Result
+            {
+                public string Id { get; set; }
+                public string Name { get; set; }
+                public AttachmentFlags Retired { get; set; }
+                public DateTime? RetiredAt { get; set; }
+            }
         
+            public RetiredAttachmentIndex_LoadAttachments()
+            {
+                Map = users => from u in users
+                    let att = LoadAttachment(u, u.AttName)
+                    select new Result
+                    {
+                        Name = att.Name,
+                        Retired = att.Flags,
+                        RetiredAt = att.RetireAt,
+                    };
+                StoreAllFields(FieldStorage.Yes);
+            }
+        }
+
         public class User
         { 
             public string Id { get; set; }
 
             public string Name { get; set; }
+
+            public string AttName { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24489/Retire-attachments-Server-Side-Indexing-add-option-to-index-retired-attachment-metadata-Phase-1

### Additional description

Added a test that checks the functionality for indexing retired attachment

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
