### PR TITLE
RavenDB-16815_v7.0_24488 -  indexing: prevent raw access to retired attachments

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/DynamicAttachment.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicAttachment.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Exceptions;
 
 namespace Raven.Server.Documents.Indexes.Static
 {
@@ -94,7 +95,8 @@ namespace Raven.Server.Documents.Indexes.Static
         public string GetContentAsString(Encoding encoding)
         {
             if (_attachment.Flags == AttachmentFlags.Retired)
-                return DynamicNullObject.Null;
+                throw new RetiredAttachmentIndexingException($"Attempted to {nameof(GetContentAsString)} retired attachment '{_attachment.Name}' (storage id: {_attachment.StorageId});" +
+                                                             $" retired attachments are no longer available locally.");
 
             if (_contentAsString == null)
             {
@@ -110,7 +112,9 @@ namespace Raven.Server.Documents.Indexes.Static
         public Stream GetContentAsStream()
         {
             if (_attachment.Flags == AttachmentFlags.Retired)
-                return null;
+                throw new RetiredAttachmentIndexingException($"Attempted to {nameof(GetContentAsStream)} on retired attachment '{_attachment.Name}' (storage id: {_attachment.StorageId});" +
+                                                             $" retired attachments are no longer available locally.");
+            
 
             _attachment.Stream.Position = 0;
 

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicAttachment.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicAttachment.cs
@@ -95,8 +95,7 @@ namespace Raven.Server.Documents.Indexes.Static
         public string GetContentAsString(Encoding encoding)
         {
             if (_attachment.Flags == AttachmentFlags.Retired)
-                throw new RetiredAttachmentIndexingException($"Attempted to {nameof(GetContentAsString)} retired attachment '{_attachment.Name}' (storage id: {_attachment.StorageId});" +
-                                                             $" retired attachments are no longer available locally.");
+                ThrowRetiredAttachmentException(nameof(GetContentAsString));
 
             if (_contentAsString == null)
             {
@@ -112,9 +111,7 @@ namespace Raven.Server.Documents.Indexes.Static
         public Stream GetContentAsStream()
         {
             if (_attachment.Flags == AttachmentFlags.Retired)
-                throw new RetiredAttachmentIndexingException($"Attempted to {nameof(GetContentAsStream)} on retired attachment '{_attachment.Name}' (storage id: {_attachment.StorageId});" +
-                                                             $" retired attachments are no longer available locally.");
-            
+                ThrowRetiredAttachmentException(nameof(GetContentAsStream));
 
             _attachment.Stream.Position = 0;
 
@@ -125,6 +122,13 @@ namespace Raven.Server.Documents.Indexes.Static
         {
             result = DynamicNullObject.Null;
             return true;
+        }
+
+        private void ThrowRetiredAttachmentException(string methodName)
+        {
+            throw new RetiredAttachmentIndexingException(
+                $"Attempted to {methodName} retired attachment '{_attachment.Name}' (storage id: {_attachment.StorageId});" +
+                " retired attachments are no longer available locally.");
         }
     }
 }

--- a/src/Raven.Server/Exceptions/RetiredAttachmentIndexingException.cs
+++ b/src/Raven.Server/Exceptions/RetiredAttachmentIndexingException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Raven.Server.Exceptions
+{
+    public sealed class RetiredAttachmentIndexingException : CriticalIndexingException
+    {
+        public RetiredAttachmentIndexingException(string message)
+            : base(message, e: null)
+        {
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_24488.cs
+++ b/test/SlowTests/Issues/RavenDB_24488.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Attachments.Retired;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Exceptions;
+using SlowTests.Server.Documents.Attachments;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+namespace SlowTests.Issues
+{
+    public class RavenDB_24488 : RetiredAttachmentsS3Base
+    {
+        public RavenDB_24488(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [AmazonS3RetryFact]
+        public async Task ShouldThrowWhenTryingToReceiveRetiredAttachmentAsStringOrAsStream()
+        {
+            string remoteFolderName = "RavenDB_24488";
+            var s3Settings = Etl.GetS3Settings(remoteFolderName);
+            try
+            {
+                using var store = GetDocumentStore();
+
+                var conf = new RetiredAttachmentsConfiguration { Disabled = false, RetireFrequencyInSec = 1, S3Settings = s3Settings };
+                await store.Maintenance.ForDatabase(store.Database).SendAsync(new ConfigureRetiredAttachmentsOperation(conf));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "John", AttName = "greeting1.txt" }, "users/1");
+                    await session.StoreAsync(new User { Name = "Johny", AttName = "greeting2.txt" }, "users/2");
+                    await session.StoreAsync(new User { Name = "JohnySilverhand", AttName = "greeting3.txt" }, "users/3");
+                    await session.SaveChangesAsync();
+                }
+
+                DateTime baseline = DateTime.UtcNow;
+                var retireAt1 = baseline.AddDays(7);
+                var retireAt2 = baseline.AddDays(365);
+                var retireAt3 = baseline.AddMinutes(1);
+
+                using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("hello")))
+                {
+                    var parameters1 = new StoreAttachmentParameters("greeting1.txt", ms) { RetireAt = retireAt1 };
+                    var putOp1 = new PutAttachmentOperation("users/1", parameters1);
+                    await store.Operations.SendAsync(putOp1);
+                    ms.Position = 0;
+                    var parameters2 = new StoreAttachmentParameters("greeting2.txt", ms) { RetireAt = retireAt2 };
+                    var putOp2 = new PutAttachmentOperation("users/2", parameters2);
+                    await store.Operations.SendAsync(putOp2);
+                    ms.Position = 0;
+                    var parameters4 = new StoreAttachmentParameters("greeting3.txt", ms) { RetireAt = retireAt3 };
+                    var putOp4 = new PutAttachmentOperation("users/3", parameters4);
+                    await store.Operations.SendAsync(putOp4);
+                }
+
+                int count = 0;
+                var retired = await WaitForValueAsync(async () =>
+                {
+                    var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                    database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(3);
+                    count += await database.RetireAttachmentsSender.RetireAttachments(int.MaxValue, int.MaxValue);
+                    return count;
+                }, 1, interval: 1000);
+
+                await AssertRetiredAttachmentIndexingExceptionAsync(new RetiredAttachmentIndexStream(), store);
+                await AssertRetiredAttachmentIndexingExceptionAsync(new RetiredAttachmentIndexString(), store);
+            }
+            finally
+            {
+                await DeleteObjects(s3Settings);
+            }
+        }
+
+        private async Task AssertRetiredAttachmentIndexingExceptionAsync(AbstractIndexCreationTask<User> index, IDocumentStore store)
+        {
+            await index.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
+
+            var indexErrors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { index.IndexName }));
+            var errorString = indexErrors[0].Errors[0].Error;
+            Assert.Contains(nameof(RetiredAttachmentIndexingException), errorString);
+        }
+
+        private class RetiredAttachmentIndexStream : AbstractIndexCreationTask<User>
+        {
+            public RetiredAttachmentIndexStream()
+            {
+                Map = users => from u in users
+                    let att = LoadAttachment(u, u.AttName).GetContentAsStream()
+                               select new
+                               {
+                                   attAsStream = att,
+                               };
+                StoreAllFields(FieldStorage.Yes);
+            }
+        }
+
+        private class RetiredAttachmentIndexString : AbstractIndexCreationTask<User>
+        {
+            public RetiredAttachmentIndexString()
+            {
+                Map = users => from u in users
+                    let att = LoadAttachment(u, u.AttName).GetContentAsString()
+                    select new
+                    {
+                        attAsStream = att,
+                    };
+                StoreAllFields(FieldStorage.Yes);
+            }
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+
+            public string AttName { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24488/Retire-attachments-Server-Side-Indexing-Block-the-retrieve-of-retired-attachments-raw-data-in-Indexing-Phase-1

### Additional description

Throws RetiredAttachmentIndexingException when GetContentAsString or GetContentAsStream is called on a retired attachment in a map index

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
